### PR TITLE
Migrate to Vite4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ There are 3 ways that you can adopt this template.
 ## Batteries included
 
 - [Vite](https://vitejs.dev/), [React](https://reactjs.org) and [TypeScript](https://www.typescriptlang.org/) - The core of this template.
+- [swc](https://swc.rs/) - A speedy JS bundler using Rust.
 - [ESLint](https://eslint.org/) using the [AirBnB ruleset](https://github.com/airbnb/javascript) and [Prettier](https://prettier.io/)
   for code formatting.
 - [Vitest](https://vitest.dev/) for running unit tests with [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/).
@@ -23,6 +24,7 @@ There are 3 ways that you can adopt this template.
 ## Side note
 
 - **`pnpm` by default**: This template assumes you're using `pnpm` as your installer and script runner. Feel free to sub it with `npm` or `yarn` as you wish.
+- **`swc` by default**: This template will enable `swc` by default. But there are some caveats (https://github.com/vitejs/vite-plugin-react-swc#caveats). If your project breaks in some way, you can toggle it off in `vite.config.ts`.
 
 ## Available Scripts
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "@types/testing-library__jest-dom": "^5.14.5",
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",
-    "@vitejs/plugin-react": "^2.2.0",
+    "@vitejs/plugin-react": "^3.0.0",
+    "@vitejs/plugin-react-swc": "^3.0.0",
     "@vitest/coverage-c8": "^0.25.6",
     "@vitest/ui": "^0.25.6",
     "eslint": "^8.29.0",
@@ -55,7 +56,7 @@
     "rimraf": "^3.0.2",
     "tsx": "^3.12.1",
     "typescript": "^4.9.4",
-    "vite": "^3.2.5",
+    "vite": "^4.0.0",
     "vitest": "^0.25.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
-    "@types/node": "^18.11.12",
+    "@types/node": "^18.11.13",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "@types/testing-library__jest-dom": "^5.14.5",
@@ -39,8 +39,8 @@
     "@typescript-eslint/parser": "^5.46.0",
     "@vitejs/plugin-react": "^3.0.0",
     "@vitejs/plugin-react-swc": "^3.0.0",
-    "@vitest/coverage-c8": "^0.25.6",
-    "@vitest/ui": "^0.25.6",
+    "@vitest/coverage-c8": "^0.25.7",
+    "@vitest/ui": "^0.25.7",
     "eslint": "^8.29.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",
@@ -57,6 +57,6 @@
     "tsx": "^3.12.1",
     "typescript": "^4.9.4",
     "vite": "^4.0.0",
-    "vitest": "^0.25.6"
+    "vitest": "^0.25.7"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 /// <reference types="vitest" />
 
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import reactBabel from '@vitejs/plugin-react';
+import reactSwc from '@vitejs/plugin-react-swc';
+
+// TOGGLE THIS IF YOU SEE STRANGE BEHAVIOR IN YOUR APP.
+// See README of plugin-react-swc: https://github.com/vitejs/vite-plugin-react-swc
+const useSwc = true;
+const react = useSwc ? reactSwc : reactBabel;
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
- Upgrade Vite to v4
- Upgrade Vitest to 0.25.7+ to support new Vite types
- Install React SWC plugin, with default will now resolve to use SWC. But there's a Caveat, see https://github.com/vitejs/vite-plugin-react-swc#caveats